### PR TITLE
Remove | as comment character

### DIFF
--- a/scribble-mode.el
+++ b/scribble-mode.el
@@ -79,7 +79,6 @@
     (modify-syntax-entry ?\n ">"   table)
 
     (modify-syntax-entry ?# "w 14" table)
-    (modify-syntax-entry ?| "_ 23bn" table)
 
     ;; Brackets and braces balance for editing convenience.
     (modify-syntax-entry ?\[ "(]  " table)


### PR DESCRIPTION
The `|` is also used for escaping to reference Racket variables, as in:
```
@(define counter 0)
@~a{Hello world @|counter|}
```
With `|` defined this way, the entire rest of the document becomes highlighted as a comment.